### PR TITLE
Fix broken character

### DIFF
--- a/src/dirhash/__init__.py
+++ b/src/dirhash/__init__.py
@@ -78,7 +78,7 @@ def dirhash(
             "name" and "data" must be included. Default is ["name", "data"] which
             means that the content (actual data) as well as the path relative to the
             root `directory` of files will affect the hash value. See "Entry
-            Properties Interpretation" section below for further details. 
+            Properties Interpretation" section below for further details.
         allow_cyclic_links: bool - If `False` (default) a `SymlinkRecursionError` is
             raised on presence of cyclic symbolic links. If set to `True` the the
             dirhash value for directory causing the cyclic link is replaced with the


### PR DESCRIPTION
The `__init__.py` currently contains a broken character (`0xc2`) at end of line 81, which means that the file has a broken encoding and cannot be imported directly. For instance if you try running `python src/dirhash/__init__.py` in the repository root, you get:

```
$ python src/dirhash/__init__.py
  File "src/dirhash/__init__.py", line 81
SyntaxError: Non-ASCII character '\xc2' in file src/dirhash/__init__.py on line 82, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```

This issue is typically hidden by the fact that when you do `pip install dirhash` pip internally uses `py_compile` to compile a `.pyc` corresponding to the `__init__.py`, and `py_compile` ignores broken file encodings. However if you delete the `.pyc` from the site packages directory you'd also be unable to `import dirhash`, because it actually has to properly parse the `.py` file.

This issue is causing quite some trouble when using an automatic `.pyc` clean up strategy. Would it be possible to release a 0.2.1 version containing this fix?