### PR TITLE
remove unused "import pkg_resources" line

### DIFF
--- a/src/dirhash/__init__.py
+++ b/src/dirhash/__init__.py
@@ -5,7 +5,6 @@ from __future__ import print_function, division
 
 import os
 import hashlib
-import pkg_resources
 
 from functools import partial
 from multiprocessing import Pool


### PR DESCRIPTION
1. It brakes the code if `setuptools` package is not installed and
2. It is also unused, since you're getting the version directly from a separate file:
```
from dirhash.version import __version__
```

Tell if there's something that I can help with to speedup the release.
Cheers.