### PR TITLE
Allow passing positional arguments through tox to pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,5 +5,5 @@ envlist = py27,py37
 deps =
     pytest-cov
 commands =
-    py.test --cov-report=xml --cov-config=.coveragerc --cov=dirhash tests/
+    py.test --cov-report=xml --cov-config=.coveragerc --cov=dirhash tests/ {posargs}
     coverage report


### PR DESCRIPTION
This change allows control over which tests should be run from the command line.

https://tox.wiki/en/latest/example/general.html#interactively-passing-positional-arguments