### PR TITLE
fix(deps): pathspec update

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     #  tag push, getting e.g. (for sister repo scantree) scantree-0+untagged.1.gd74b1d5,
     #  see: https://github.com/andhus/scantree/actions/runs/7485873305/job/20375116541#step:7:42)
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
     - name: Install pypa/build
@@ -34,7 +34,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -54,7 +54,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -73,12 +73,12 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      uses: sigstore/gh-action-sigstore-python@v2.1.1
       with:
         inputs: >-
           ./dist/*.tar.gz
@@ -118,7 +118,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.python-version }}-tox-${{ hashFiles('setup.py') }}-${{ hashFiles('setup.cfg') }} }}
     - name: Test with tox
       run: tox
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author="Anders Huss",
     author_email="andhus@kth.se",
     license='MIT',
-    install_requires=['scantree>=0.0.2', 'pathspec<0.10.0'],
+    install_requires=['scantree>=0.0.2'],
     packages=find_packages('src'),
     package_dir={'': 'src'},
     include_package_data=True,


### PR DESCRIPTION
removing limit to pathspec<0.10.0 as the one failing integration test was IMHO incorrect 

it expected to see visible files inside invisible folder, which is not a real situation 
pathspec did fix the behavior, and so should we

+ github actions updates