### PR TITLE
Add requires-python metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     author="Anders Huss",
     author_email="andhus@kth.se",
     license="MIT",
+    python_requires=">=3.8",
     install_requires=["scantree"],
     packages=find_packages("src"),
     package_dir={"": "src"},


### PR DESCRIPTION
* Add requires-python metadata through the addition of setuptools's python_requires in setup.py.
   - c.f. https://peps.python.org/pep-0621/#requires-python

* The addition of requires-python is to provide guards to keep older CPython versions from installing releases that could contain unrunnable code.