### PR TITLE
Sets lower bound for scantree for windows support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author_email="andhus@kth.se",
     license="MIT",
     python_requires=">=3.8",
-    install_requires=["scantree"],
+    install_requires=["scantree>=0.0.4"],
     packages=find_packages("src"),
     package_dir={"": "src"},
     include_package_data=True,


### PR DESCRIPTION
No reason to be on an older `scantree` version, tests only run with the latest and it is required for Windows, so making it explicit here.